### PR TITLE
fix: #90

### DIFF
--- a/internal/scenes/scene_select.go
+++ b/internal/scenes/scene_select.go
@@ -118,7 +118,10 @@ func (s *SelectScene) Update(state *GameState) {
 		}
 		s.selectChanged = true
 		s.selectedIndex = i
-		chara.Selected = s.charaList[i]
+	}
+
+	if s.selectChanged {
+		chara.Selected = s.charaList[s.selectedIndex]
 	}
 
 	for i := range s.selectArray {


### PR DESCRIPTION
直した。
マウスで選択ボタンを押した際とは違って、キーボード入力で選択変更した時に選択キャラクターの内部データに反映できていないのが原因だった。

close #90 