### PR TITLE
fix: change attack's rect

### DIFF
--- a/internal/character/player.go
+++ b/internal/character/player.go
@@ -94,7 +94,7 @@ func (p *Player) InitializeWithLanes(lanes *field.Lanes) error {
 		view.Vector{X: view.DrawPosition + rectOffset, Y: initialY + rectOffset},
 		view.Vector{X: view.DrawPosition + float64(w) - rectOffset, Y: initialY + float64(h) - rectOffset})
 	p.atkRect = view.NewHitRectangle(
-		view.Vector{X: view.DrawPosition + float64(w) + 5 + rectOffset, Y: initialY + 20 + rectOffset},
+		view.Vector{X: view.DrawPosition + rectOffset, Y: initialY + 20 + rectOffset},
 		view.Vector{X: view.DrawPosition + float64(w) + 5 + float64(aw) - rectOffset, Y: initialY + 20 + float64(ah) - rectOffset})
 
 	return nil


### PR DESCRIPTION
攻撃の当たり判定が「ほぼ攻撃画像の範囲」になるようにしていたが、それだと障害物に当たっている状況において攻撃で障害物を除去するのが困難になってしまっていた。
これを解決するため、「キャラクターに被っている領域」も攻撃の当たり判定に含めることにした。